### PR TITLE
Added Readme, new ASCII art for UCF, and fixed issue with username and email

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+# flpoly-programming-team
+Tools and configs for the Florida Polytechnic Programming Team  
+
+The vim header plugin has four commands.  
+
+- `HeaderAdd` - Adds a header to the file.  
+- `HeaderSetUser <username>` - Sets the user that is displayed in the header.  
+- `HeaderSetEmail <email address>` - Sets the email that is displayed in the header.  
+- `HeaderSetArt <art>` - Sets the ASCII art in the header.  
+
+The values you pick for your header will reset every time vim is closed. To make them permanent,
+add them as autocommands in your `.vimrc`. For example, if my username was JohnDoe1, my email was
+john_doe@aol.net, and my preferred ASCII art was 'poly1', I'd add these three lines to my `.vimrc`:
+```
+autocmd VimEnter * HeaderSetUser JohnDoe1
+autocmd VimEnter * HeaderSetEmail john_doe@aol.net
+autocmd VimEnter * HeaderSetArt poly1
+```
+
+Here are the current ASCII images to choose from:   
+```
+poly1:
+
+        |\           
+  ------| \----      
+  |    \`  \  |  p   
+  |  \`-\   \ |  o   
+  |---\  \   `|  l   
+  | ` .\  \   |  y  
+  -------------
+
+
+ucf1:
+
+   \\ \\               
+   ||_|| ____          
+   \___// __/ ____     
+       | |__ / ___|    
+        \___|| |__     
+             |  _/     
+             |_|       
+
+
+ucf2:
+
+  university of          
+  central                
+  florida                
+                   ]
+ <::::::::::::::::}]xxx@
+                   ]
+```

--- a/vim-header/plugin/poly-header.vim
+++ b/vim-header/plugin/poly-header.vim
@@ -6,19 +6,45 @@
 "    By: cshepard6055 <cshepard6055@floridapoly.edu>    |  \`-\   \ |  o       "
 "                                                       |---\  \   `|  l       "
 "    Created: 2017/09/04 12:42:13 by cshepard6055       | ` .\  \   |  y       "
-"    Updated: 2017/09/04 18:22:17 by cshepard6055       -------------          "
+"    Updated: 2018/05/03 21:05:23 by tigermoo           -------------          "
 "                                                                              "
 " **************************************************************************** "
 
-let s:asciiart = [
-            \"                 |\      ",
-            \"     ------| \\----      ",
-            \"      |    \`  \  |  p   ",
-            \"      |  \`-\   \ |  o   ",
-            \"      |---\  \   `|  l   ",
-            \"      | ` .\  \   |  y   ",
-            \"          -------------      "
+let s:poly1 = [
+            \'            |\           ',
+            \'      ------| \----      ',
+            \'      |    \`  \  |  p   ',
+            \'      |  \`-\   \ |  o   ',
+            \'      |---\  \   `|  l   ',
+            \'      | ` .\  \   |  y   ',
+            \'      -------------      '
 			\]
+
+let s:ucf1 = [
+            \'     \\ \\               ',
+            \'     ||_|| ____          ',
+            \'     \___// __/ ____     ',
+            \'         | |__ / ___|    ',
+            \'          \___|| |__     ',
+            \'               |  _/     ',
+            \'               |_|       '
+            \]
+
+let s:ucf2 = [
+            \'                         ',
+            \'  university of          ',
+            \'  central                ',
+            \'  florida                ',
+            \'                   ]     ',
+            \' <::::::::::::::::}]xxx@ ',
+            \'                   ]     '
+            \]
+
+let s:artoptions = {'poly1' : s:poly1, 'ucf1' : s:ucf1, 'ucf2' : s:ucf2,}
+let s:asciiart = s:poly1
+
+let s:user = 'default'
+let s:email = 'default'
 
 let s:start		= '/*'
 let s:end		= '*/'
@@ -82,28 +108,12 @@ function! s:line(n)
 	elseif a:n == 4 " filename
 		return s:textline(s:filename(), s:ascii(a:n))
 	elseif a:n == 6 " author
-		return s:textline("By: " . s:user() . " <" . s:mail() . ">", s:ascii(a:n))
+		return s:textline("By: " . s:user . " <" . s:email . ">", s:ascii(a:n))
 	elseif a:n == 8 " created
-		return s:textline("Created: " . s:date() . " by " . s:user(), s:ascii(a:n))
+		return s:textline("Created: " . s:date() . " by " . s:user, s:ascii(a:n))
 	elseif a:n == 9 " updated
-		return s:textline("Updated: " . s:date() . " by " . s:user(), s:ascii(a:n))
+		return s:textline("Updated: " . s:date() . " by " . s:user, s:ascii(a:n))
 	endif
-endfunction
-
-function! s:user()
-	let l:user = $USER
-	if strlen(l:user) == 0
-		let l:user = "flpoly-students"
-	endif
-	return l:user
-endfunction
-
-function! s:mail()
-	let l:mail = $MAIL
-	if strlen(l:mail) == 0
-		let l:mail = "allstudents@floridapoly.edu"
-	endif
-	return l:mail
 endfunction
 
 function! s:filename()
@@ -149,7 +159,26 @@ function! s:stdheader()
 	endif
 endfunction
 
-" Bind command and shortcut
-command! Stdheader call s:stdheader ()
+function! s:setUser(name)
+    let s:user = a:name
+endfunction
+
+function! s:setEmail(email)
+    let s:email = a:email
+endfunction
+
+function! s:setArt(art)
+    let s:asciiart = s:artoptions[a:art]
+endfunction
+
+" Commands
+command! -nargs=1 HeaderSetUser call s:setUser(<f-args>)
+command! -nargs=1 HeaderSetEmail call s:setEmail(<f-args>)
+command! -nargs=1 HeaderSetArt call s:setArt(<f-args>)
+command! HeaderAdd call s:stdheader ()
+
+" Key bindings
 nmap <f1> <esc>:Stdheader<CR>
+
+" Call update function after each write
 autocmd BufWritePre * call s:update ()


### PR DESCRIPTION
I made it so the username, email, and ascii art are all configurable via commands in the editor. To make these changes permanent they can be added to `.vimrc` or `init.vim`. See the readme for detailed instructions.